### PR TITLE
Added ByIgnoringPropertiesOfTypeAssignableTo extension method and refactored core to make it possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,19 @@ FakesAssemblies/
 
 # Visual Studio 6 workspace options file
 *.opt
+
+# JetBrains Rider
+.idea/
+*.sln.iml
+
+*.suo
+*.user
+.vs/
+[Bb]in/
+[Oo]bj/
+_UpgradeReport_Files/
+[Pp]ackages/
+
+Thumbs.db
+Desktop.ini
+.DS_Store

--- a/src/Destructurama.ByIgnoring/ByIgnoring/DestructureByIgnoringPolicy.cs
+++ b/src/Destructurama.ByIgnoring/ByIgnoring/DestructureByIgnoringPolicy.cs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Serilog.Core;
 using Serilog.Debugging;
@@ -23,41 +23,56 @@ using Serilog.Events;
 
 namespace Destructurama.ByIgnoring
 {
-    class DestructureByIgnoringPolicy<TDestructure> : IDestructuringPolicy
+    class DestructureByIgnoringPolicy : IDestructuringPolicy
     {
-        private readonly IEnumerable<PropertyInfo> _propertiesToInclude;
-        private readonly Type _destructureType;
+        private readonly Func<object, bool> _handleDestructuringPredicate;
+        private readonly Func<PropertyInfo, bool>[] _ignoredPropertyPredicates;
 
-        public DestructureByIgnoringPolicy(params Expression<Func<TDestructure, object>>[] ignoredProperties)
+        private readonly ConcurrentDictionary<Type, PropertyInfo[]> _cache = new();
+
+        public DestructureByIgnoringPolicy(Func<object, bool> handleDestructuringPredicate, params Func<PropertyInfo, bool>[] ignoredPropertyPredicates)
         {
-            _destructureType = typeof(TDestructure);
-            var namesOfPropertiesToIgnore = ignoredProperties.Select(GetNameOfPropertyToIgnore).ToArray();
-            var runtimeProperties = _destructureType.GetRuntimeProperties();
+            _handleDestructuringPredicate = handleDestructuringPredicate ?? throw new ArgumentNullException(nameof(handleDestructuringPredicate));
+            _ignoredPropertyPredicates = ignoredPropertyPredicates ?? throw new ArgumentNullException(nameof(ignoredPropertyPredicates));
 
-            _propertiesToInclude = runtimeProperties
-                .Where(p => p.CanRead)
-                .Where(p => !p.GetMethod.IsStatic)
-                .Where(p => p.GetIndexParameters().Length == 0)
-                .Where(p => !namesOfPropertiesToIgnore.Contains(p.Name)).ToArray();
+            if (!ignoredPropertyPredicates.Any())
+            {
+                throw new ArgumentOutOfRangeException(nameof(ignoredPropertyPredicates), "at least one ignore rule must be supplied");
+            }
         }
 
         public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, out LogEventPropertyValue result)
         {
-            if (value == null || value.GetType() != typeof(TDestructure))
+            if (value == null || !_handleDestructuringPredicate(value))
             {
                 result = null;
                 return false;
             }
 
-            result = BuildStructure(value, propertyValueFactory);
+            var type = value.GetType();
+            var includedProperties = _cache.GetOrAdd(type, GetIncludedProperties);
+
+            result = BuildStructure(value, propertyValueFactory, includedProperties, type);
 
             return true;
         }
 
-        private LogEventPropertyValue BuildStructure(object value, ILogEventPropertyValueFactory propertyValueFactory)
+        private PropertyInfo[] GetIncludedProperties(Type type)
+        {
+            var eligibleRuntimeProperties = type.GetRuntimeProperties()
+                .Where(p => p.CanRead)
+                .Where(p => p.GetMethod?.IsStatic != true)
+                .Where(p => p.GetIndexParameters().Length == 0);
+
+            return eligibleRuntimeProperties
+                .Where(p => _ignoredPropertyPredicates.All(ignoreFunc => ignoreFunc(p) == false))
+                .ToArray();
+        }
+
+        private static LogEventPropertyValue BuildStructure(object value, ILogEventPropertyValueFactory propertyValueFactory, IEnumerable<PropertyInfo> propertiesToInclude, Type destructureType)
         {
             var structureProperties = new List<LogEventProperty>();
-            foreach (var propertyInfo in _propertiesToInclude)
+            foreach (var propertyInfo in propertiesToInclude)
             {
                 object propertyValue;
                 try
@@ -75,17 +90,12 @@ namespace Destructurama.ByIgnoring
                 structureProperties.Add(new LogEventProperty(propertyInfo.Name, logEventPropertyValue));
             }
 
-            return new StructureValue(structureProperties, _destructureType.Name);
+            return new StructureValue(structureProperties, destructureType.Name);
         }
 
         private static LogEventPropertyValue BuildLogEventProperty(object propertyValue, ILogEventPropertyValueFactory propertyValueFactory)
         {
             return propertyValue == null ? new ScalarValue(null) : propertyValueFactory.CreatePropertyValue(propertyValue, true);
-        }
-
-        private static string GetNameOfPropertyToIgnore(Expression<Func<TDestructure, object>> ignoredProperty)
-        {
-            return ignoredProperty.GetPropertyNameFromExpression();
         }
     }
 }

--- a/src/Destructurama.ByIgnoring/ByIgnoring/IgnoredPropertyExpressionExtensions.cs
+++ b/src/Destructurama.ByIgnoring/ByIgnoring/IgnoredPropertyExpressionExtensions.cs
@@ -17,11 +17,21 @@ using System.Linq.Expressions;
 
 namespace Destructurama.ByIgnoring
 {
-    static class IgnoredPropertyExpressionExtensions
+    /// <summary>
+    /// Extension methods used to obtain property names.
+    /// </summary>
+    public static class IgnoredPropertyExpressionExtensions
     {
         private const string expressionNotSupported = "A property name cannot be retrieved from function expression with body of type {0}. " +
                                                       "Only function expressions that access a property are currently supported. e.g. obj => obj.Property";
 
+        /// <summary>
+        /// Obtains the name of a property using an expression.
+        /// </summary>
+        /// <param name="ignoredProperty"></param>
+        /// <typeparam name="TDestructureType"></typeparam>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
         public static string GetPropertyNameFromExpression<TDestructureType>(this Expression<Func<TDestructureType, object>> ignoredProperty)
         {
             var expressionBody = ignoredProperty.Body;

--- a/src/Destructurama.ByIgnoring/ByIgnoring/IgnoredPropertyExpressionExtensions.cs
+++ b/src/Destructurama.ByIgnoring/ByIgnoring/IgnoredPropertyExpressionExtensions.cs
@@ -26,12 +26,8 @@ namespace Destructurama.ByIgnoring
                                                       "Only function expressions that access a property are currently supported. e.g. obj => obj.Property";
 
         /// <summary>
-        /// Obtains the name of a property using an expression.
+        /// Obtains the name of a property of the provided TDestructureType using an expression.
         /// </summary>
-        /// <param name="ignoredProperty"></param>
-        /// <typeparam name="TDestructureType"></typeparam>
-        /// <returns></returns>
-        /// <exception cref="ArgumentException"></exception>
         public static string GetPropertyNameFromExpression<TDestructureType>(this Expression<Func<TDestructureType, object>> ignoredProperty)
         {
             var expressionBody = ignoredProperty.Body;

--- a/src/Destructurama.ByIgnoring/Destructurama.ByIgnoring.csproj
+++ b/src/Destructurama.ByIgnoring/Destructurama.ByIgnoring.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <VersionPrefix>1.1.1</VersionPrefix>
     <PackageId>Destructurama.ByIgnoring</PackageId>
@@ -27,12 +27,12 @@
 
   <ItemGroup>
     <None Include="..\assets\Destructurama.snk" Link="Destructurama.snk" />
-    <None Include="..\..\assets\icon.png" Pack="true" PackagePath=""/>
+    <None Include="..\..\assets\icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Condition="'$(TargetFramework)' == 'netstandard1.0'" Include="Serilog" Version="2.5.0" />
-    <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="Serilog" Version="[2.8.0,3.0.0)" />
+    <PackageReference Condition="'$(TargetFramework)' == 'netstandard1.1'" Include="Serilog" Version="2.*" />
+    <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="Serilog" Version="[2.10.0,3.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
+++ b/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
@@ -48,7 +48,7 @@ namespace Destructurama
             configuration.ByIgnoringPropertiesWhere(obj => obj is TDestructure, ignoredProperty);
 
         /// <summary>
-        /// Destructure.ByIgnoringProperties takes one or more expressions that access a property, e.g. obj => obj.Property, and uses the property names to determine which
+        /// Destructure.ByIgnoringPropertiesWhere takes one or more expressions that access a property, e.g. obj => obj.Property, and uses the property names to determine which
         /// properties are ignored when an object for which destructureFunc returns true is destructured by serilog.
         /// </summary>
         /// <param name="configuration">The logger configuration to apply configuration to.</param>

--- a/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
+++ b/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
@@ -35,7 +35,7 @@ namespace Destructurama
         /// <param name="ignoredProperty">The function expressions that expose the properties to ignore.</param>
         /// <returns>An object allowing configuration to continue.</returns>
         public static LoggerConfiguration ByIgnoringProperties<TDestruture>(this LoggerDestructuringConfiguration configuration, params Expression<Func<TDestruture, object>>[] ignoredProperty) =>
-            configuration.ByIgnoringProperties(obj => obj.GetType() == typeof(TDestruture), ignoredProperty);
+            configuration.ByIgnoringPropertiesWhere(obj => obj.GetType() == typeof(TDestruture), ignoredProperty);
 
         /// <summary>
         /// Destructure.ByIgnoringProperties takes one or more expressions that access a property, e.g. obj => obj.Property, and uses the property names to determine which
@@ -45,7 +45,7 @@ namespace Destructurama
         /// <param name="ignoredProperty">The function expressions that expose the properties to ignore.</param>
         /// <returns>An object allowing configuration to continue.</returns>
         public static LoggerConfiguration ByIgnoringPropertiesOfTypeAssignableTo<TDestruture>(this LoggerDestructuringConfiguration configuration, params Expression<Func<TDestruture, object>>[] ignoredProperty) =>
-            configuration.ByIgnoringProperties(obj => obj is TDestruture, ignoredProperty);
+            configuration.ByIgnoringPropertiesWhere(obj => obj is TDestruture, ignoredProperty);
 
         /// <summary>
         /// Destructure.ByIgnoringProperties takes one or more expressions that access a property, e.g. obj => obj.Property, and uses the property names to determine which
@@ -55,9 +55,9 @@ namespace Destructurama
         /// <param name="handleDestructuringPredicate">Given an object to destructure, should this policy take effect?</param>
         /// <param name="ignoredProperty">The function expressions that expose the properties to ignore.</param>
         /// <returns>An object allowing configuration to continue.</returns>
-        public static LoggerConfiguration ByIgnoringProperties<TDestruture>(this LoggerDestructuringConfiguration configuration, Func<object, bool> handleDestructuringPredicate, params Expression<Func<TDestruture, object>>[] ignoredProperty)
+        public static LoggerConfiguration ByIgnoringPropertiesWhere<TDestruture>(this LoggerDestructuringConfiguration configuration, Func<object, bool> handleDestructuringPredicate, params Expression<Func<TDestruture, object>>[] ignoredProperty)
         {
-            return configuration.ByIgnoringProperties(
+            return configuration.ByIgnoringPropertiesWhere(
                 handleDestructuringPredicate,
                 ignoredProperty
                     .Select(x => x.GetPropertyNameFromExpression())
@@ -73,7 +73,7 @@ namespace Destructurama
         /// <param name="handleDestructuringPredicate">Given an object to destructure, should this policy take effect?</param>
         /// <param name="ignoredPropertyPredicates">When the predicate returns true for a provided property, said will be ignored when destructured by serilog.</param>
         /// <returns>An object allowing configuration to continue.</returns>
-        public static LoggerConfiguration ByIgnoringProperties(this LoggerDestructuringConfiguration configuration, Func<object, bool> handleDestructuringPredicate, params Func<PropertyInfo, bool>[] ignoredPropertyPredicates) =>
+        public static LoggerConfiguration ByIgnoringPropertiesWhere(this LoggerDestructuringConfiguration configuration, Func<object, bool> handleDestructuringPredicate, params Func<PropertyInfo, bool>[] ignoredPropertyPredicates) =>
             configuration.With(new DestructureByIgnoringPolicy(handleDestructuringPredicate, ignoredPropertyPredicates));
     }
 }

--- a/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
+++ b/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
@@ -39,7 +39,7 @@ namespace Destructurama
 
         /// <summary>
         /// Destructure.ByIgnoringProperties takes one or more expressions that access a property, e.g. obj => obj.Property, and uses the property names to determine which
-        /// properties are ignored when an object of type assignable to TDestruture is destructured by serilog.
+        /// properties are ignored when an object of type assignable to TDestructure is destructured by serilog.
         /// </summary>
         /// <param name="configuration">The logger configuration to apply configuration to.</param>
         /// <param name="ignoredProperty">The function expressions that expose the properties to ignore.</param>

--- a/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
+++ b/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
@@ -44,8 +44,8 @@ namespace Destructurama
         /// <param name="configuration">The logger configuration to apply configuration to.</param>
         /// <param name="ignoredProperty">The function expressions that expose the properties to ignore.</param>
         /// <returns>An object allowing configuration to continue.</returns>
-        public static LoggerConfiguration ByIgnoringPropertiesOfTypeAssignableTo<TDestruture>(this LoggerDestructuringConfiguration configuration, params Expression<Func<TDestruture, object>>[] ignoredProperty) =>
-            configuration.ByIgnoringPropertiesWhere(obj => obj is TDestruture, ignoredProperty);
+        public static LoggerConfiguration ByIgnoringPropertiesOfTypeAssignableTo<TDestructure>(this LoggerDestructuringConfiguration configuration, params Expression<Func<TDestructure, object>>[] ignoredProperty) =>
+            configuration.ByIgnoringPropertiesWhere(obj => obj is TDestructure, ignoredProperty);
 
         /// <summary>
         /// Destructure.ByIgnoringProperties takes one or more expressions that access a property, e.g. obj => obj.Property, and uses the property names to determine which

--- a/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
+++ b/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
@@ -32,20 +32,20 @@ namespace Destructurama
         /// properties are ignored when an object of type TDestruture is destructured by serilog.
         /// </summary>
         /// <param name="configuration">The logger configuration to apply configuration to.</param>
-        /// <param name="ignoredProperty">The function expressions that expose the properties to ignore.</param>
+        /// <param name="ignoredProperties">The function expressions that expose the properties to ignore.</param>
         /// <returns>An object allowing configuration to continue.</returns>
-        public static LoggerConfiguration ByIgnoringProperties<TDestructure>(this LoggerDestructuringConfiguration configuration, params Expression<Func<TDestructure, object>>[] ignoredProperty) =>
-            configuration.ByIgnoringPropertiesWhere(obj => obj.GetType() == typeof(TDestructure), ignoredProperty);
+        public static LoggerConfiguration ByIgnoringProperties<TDestructure>(this LoggerDestructuringConfiguration configuration, params Expression<Func<TDestructure, object>>[] ignoredProperties) =>
+            configuration.ByIgnoringPropertiesWhere(obj => obj.GetType() == typeof(TDestructure), ignoredProperties);
 
         /// <summary>
         /// Destructure.ByIgnoringPropertiesOfTypeAssignableTo takes one or more expressions that access a property, e.g. obj => obj.Property, and uses the property names to determine which
         /// properties are ignored when an object of type assignable to TDestructure is destructured by serilog.
         /// </summary>
         /// <param name="configuration">The logger configuration to apply configuration to.</param>
-        /// <param name="ignoredProperty">The function expressions that expose the properties to ignore.</param>
+        /// <param name="ignoredProperties">The function expressions that expose the properties to ignore.</param>
         /// <returns>An object allowing configuration to continue.</returns>
-        public static LoggerConfiguration ByIgnoringPropertiesOfTypeAssignableTo<TDestructure>(this LoggerDestructuringConfiguration configuration, params Expression<Func<TDestructure, object>>[] ignoredProperty) =>
-            configuration.ByIgnoringPropertiesWhere(obj => obj is TDestructure, ignoredProperty);
+        public static LoggerConfiguration ByIgnoringPropertiesOfTypeAssignableTo<TDestructure>(this LoggerDestructuringConfiguration configuration, params Expression<Func<TDestructure, object>>[] ignoredProperties) =>
+            configuration.ByIgnoringPropertiesWhere(obj => obj is TDestructure, ignoredProperties);
 
         /// <summary>
         /// Destructure.ByIgnoringPropertiesWhere takes one or more expressions that access a property, e.g. obj => obj.Property, and uses the property names to determine which
@@ -53,13 +53,13 @@ namespace Destructurama
         /// </summary>
         /// <param name="configuration">The logger configuration to apply configuration to.</param>
         /// <param name="handleDestructuringPredicate">Given an object to destructure, should this policy take effect?</param>
-        /// <param name="ignoredProperty">The function expressions that expose the properties to ignore.</param>
+        /// <param name="ignoredProperties">The function expressions that expose the properties to ignore.</param>
         /// <returns>An object allowing configuration to continue.</returns>
-        public static LoggerConfiguration ByIgnoringPropertiesWhere<TDestruture>(this LoggerDestructuringConfiguration configuration, Func<object, bool> handleDestructuringPredicate, params Expression<Func<TDestruture, object>>[] ignoredProperty)
+        public static LoggerConfiguration ByIgnoringPropertiesWhere<TDestruture>(this LoggerDestructuringConfiguration configuration, Func<object, bool> handleDestructuringPredicate, params Expression<Func<TDestruture, object>>[] ignoredProperties)
         {
             return configuration.ByIgnoringPropertiesWhere(
                 handleDestructuringPredicate,
-                ignoredProperty
+                ignoredProperties
                     .Select(x => x.GetPropertyNameFromExpression())
                     .Select<string, Func<PropertyInfo, bool>>(ignoredPropertyName => pi => pi.Name == ignoredPropertyName)
                     .ToArray());

--- a/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
+++ b/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
@@ -66,7 +66,7 @@ namespace Destructurama
         }
 
         /// <summary>
-        /// Destructure.ByIgnoringProperties takes one or more ignoredProperty predicates that when true indicates a given property is to be ignored when destructured by serilog.
+        /// Destructure.ByIgnoringPropertiesWhere takes one or more ignoredProperty predicates that when true indicates a given property is to be ignored when destructured by serilog.
         /// This ignoring only comes into play for an object where destructurePredicate returns true.
         /// </summary>
         /// <param name="configuration">The logger configuration to apply configuration to.</param>

--- a/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
+++ b/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
@@ -49,7 +49,7 @@ namespace Destructurama
 
         /// <summary>
         /// Destructure.ByIgnoringPropertiesWhere takes one or more expressions that access a property, e.g. obj => obj.Property, and uses the property names to determine which
-        /// properties are ignored when an object for which destructureFunc returns true is destructured by serilog.
+        /// properties are ignored when an object for which handleDestructuringPredicate returns true is destructured by serilog.
         /// </summary>
         /// <param name="configuration">The logger configuration to apply configuration to.</param>
         /// <param name="handleDestructuringPredicate">Given an object to destructure, should this policy take effect?</param>

--- a/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
+++ b/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
@@ -34,8 +34,8 @@ namespace Destructurama
         /// <param name="configuration">The logger configuration to apply configuration to.</param>
         /// <param name="ignoredProperty">The function expressions that expose the properties to ignore.</param>
         /// <returns>An object allowing configuration to continue.</returns>
-        public static LoggerConfiguration ByIgnoringProperties<TDestruture>(this LoggerDestructuringConfiguration configuration, params Expression<Func<TDestruture, object>>[] ignoredProperty) =>
-            configuration.ByIgnoringPropertiesWhere(obj => obj.GetType() == typeof(TDestruture), ignoredProperty);
+        public static LoggerConfiguration ByIgnoringProperties<TDestructure>(this LoggerDestructuringConfiguration configuration, params Expression<Func<TDestructure, object>>[] ignoredProperty) =>
+            configuration.ByIgnoringPropertiesWhere(obj => obj.GetType() == typeof(TDestructure), ignoredProperty);
 
         /// <summary>
         /// Destructure.ByIgnoringProperties takes one or more expressions that access a property, e.g. obj => obj.Property, and uses the property names to determine which

--- a/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
+++ b/src/Destructurama.ByIgnoring/LoggerConfigurationIgnoreExtensions.cs
@@ -38,7 +38,7 @@ namespace Destructurama
             configuration.ByIgnoringPropertiesWhere(obj => obj.GetType() == typeof(TDestructure), ignoredProperty);
 
         /// <summary>
-        /// Destructure.ByIgnoringProperties takes one or more expressions that access a property, e.g. obj => obj.Property, and uses the property names to determine which
+        /// Destructure.ByIgnoringPropertiesOfTypeAssignableTo takes one or more expressions that access a property, e.g. obj => obj.Property, and uses the property names to determine which
         /// properties are ignored when an object of type assignable to TDestructure is destructured by serilog.
         /// </summary>
         /// <param name="configuration">The logger configuration to apply configuration to.</param>

--- a/test/Destructurama.ByIgnoring.Tests/Destructurama.ByIgnoring.Tests.csproj
+++ b/test/Destructurama.ByIgnoring.Tests/Destructurama.ByIgnoring.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp2.2;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Destructurama.ByIgnoring.Tests</RootNamespace>
     <AssemblyName>Destructurama.ByIgnoring.Tests</AssemblyName>

--- a/test/Destructurama.ByIgnoring.Tests/Destructurama.ByIgnoring.Tests.csproj
+++ b/test/Destructurama.ByIgnoring.Tests/Destructurama.ByIgnoring.Tests.csproj
@@ -1,13 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;net7.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Destructurama.ByIgnoring.Tests</RootNamespace>
     <AssemblyName>Destructurama.ByIgnoring.Tests</AssemblyName>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
     <PackageReference Include="NUnit" Version="3.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />

--- a/test/Destructurama.ByIgnoring.Tests/Destructurama.ByIgnoring.Tests.csproj
+++ b/test/Destructurama.ByIgnoring.Tests/Destructurama.ByIgnoring.Tests.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>latest</LangVersion>
-    <RootNamespace>Destructurama.ByIgnoring.Tests</RootNamespace>
-    <AssemblyName>Destructurama.ByIgnoring.Tests</AssemblyName>
     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 

--- a/test/Destructurama.ByIgnoring.Tests/Destructurama.ByIgnoring.Tests.csproj
+++ b/test/Destructurama.ByIgnoring.Tests/Destructurama.ByIgnoring.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;net7.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Destructurama.ByIgnoring.Tests</RootNamespace>
     <AssemblyName>Destructurama.ByIgnoring.Tests</AssemblyName>

--- a/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringPropertiesOfTypeAssignableToTests.cs
+++ b/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringPropertiesOfTypeAssignableToTests.cs
@@ -47,7 +47,7 @@ namespace Destructurama.ByIgnoring.Tests
             var sv = (StructureValue)evt.Properties["Ignored"];
             var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
-            props.Should().BeEquivalentTo(testCase.ExpectedPropertiesLogged);
+            props.Should().BeEquivalentTo(testCase.ExpectedPropertiesLogged, options => options.UsingSerilogTypeComparisons());
         }
 
         [TestCaseSource(typeof(ByIgnoringPropertiesOfTypeAssignableToTestCases), nameof(ByIgnoringPropertiesOfTypeAssignableToTestCases.ShouldThrowExceptionTestCases))]

--- a/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringPropertiesOfTypeAssignableToTests.cs
+++ b/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringPropertiesOfTypeAssignableToTests.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 using Destructurama.ByIgnoring.Tests.Support;

--- a/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringPropertiesOfTypeAssignableToTests.cs
+++ b/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringPropertiesOfTypeAssignableToTests.cs
@@ -45,7 +45,7 @@ namespace Destructurama.ByIgnoring.Tests
             // Execute
             Action configureByIgnoringAction = () => config.Destructure.ByIgnoringPropertiesOfTypeAssignableTo(testCase.IgnoredProperties);
 
-            // Execute
+            // Verify
             configureByIgnoringAction
                 .Should()
                 .Throw<Exception>()

--- a/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringPropertiesOfTypeAssignableToTests.cs
+++ b/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringPropertiesOfTypeAssignableToTests.cs
@@ -11,17 +11,18 @@ using Serilog.Events;
 namespace Destructurama.ByIgnoring.Tests
 {
     [TestFixture]
-    public class DestructureByIgnoringTests
+    public class DestructureByIgnoringPropertiesOfTypeAssignableToTests
     {
-        [TestCaseSource(typeof(ByIgnoringTestCases), nameof(ByIgnoringTestCases.DestructureMeSuccessTestCases))]
+        [TestCaseSource(typeof(ByIgnoringPropertiesOfTypeAssignableToTestCases), nameof(ByIgnoringPropertiesOfTypeAssignableToTestCases.IDestructureMeSuccessTestCases))]
         [TestCaseSource(typeof(ByIgnoringTestCases), nameof(ByIgnoringTestCases.OnlySetterSuccessTestCases))]
+        [TestCaseSource(typeof(ByIgnoringTestCases), nameof(ByIgnoringTestCases.DestructureMeSuccessTestCases))] // a type should be assignable to itself, so these should all pass
         public void PropertiesAreIgnoredWhenDestructuring<T>(ByIgnoringTestCase<T> testCase)
         {
             // Setup
             LogEvent evt = null;
 
             var log = new LoggerConfiguration()
-                .Destructure.ByIgnoringProperties(testCase.IgnoredProperties)
+                .Destructure.ByIgnoringPropertiesOfTypeAssignableTo(testCase.IgnoredProperties)
                 .WriteTo.Sink(new DelegatingSink(e => evt = e))
                 .CreateLogger();
 
@@ -35,14 +36,14 @@ namespace Destructurama.ByIgnoring.Tests
             props.Should().BeEquivalentTo(testCase.ExpectedPropertiesLogged);
         }
 
-        [TestCaseSource(typeof(ByIgnoringTestCases), nameof(ByIgnoringTestCases.ShouldThrowExceptionTestCases))]
+        [TestCaseSource(typeof(ByIgnoringPropertiesOfTypeAssignableToTestCases), nameof(ByIgnoringPropertiesOfTypeAssignableToTestCases.ShouldThrowExceptionTestCases))]
         public void ExceptionThrownWhenRegisteringDestructure<T>(ByIgnoreExceptionTestCase<T> testCase)
         {
             // Setup
             var config = new LoggerConfiguration();
 
             // Execute
-            Action configureByIgnoringAction = () => config.Destructure.ByIgnoringProperties(testCase.IgnoredProperties);
+            Action configureByIgnoringAction = () => config.Destructure.ByIgnoringPropertiesOfTypeAssignableTo(testCase.IgnoredProperties);
 
             // Execute
             configureByIgnoringAction

--- a/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringTests.cs
+++ b/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringTests.cs
@@ -46,7 +46,7 @@ namespace Destructurama.ByIgnoring.Tests
             var sv = (StructureValue)evt.Properties["Ignored"];
             var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
-            props.Should().BeEquivalentTo(testCase.ExpectedPropertiesLogged);
+            props.Should().BeEquivalentTo(testCase.ExpectedPropertiesLogged, options => options.UsingSerilogTypeComparisons());
         }
 
         [TestCaseSource(typeof(ByIgnoringTestCases), nameof(ByIgnoringTestCases.ShouldThrowExceptionTestCases))]

--- a/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringTests.cs
+++ b/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringTests.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 using Destructurama.ByIgnoring.Tests.Support;

--- a/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringTests.cs
+++ b/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringTests.cs
@@ -44,7 +44,7 @@ namespace Destructurama.ByIgnoring.Tests
             // Execute
             Action configureByIgnoringAction = () => config.Destructure.ByIgnoringProperties(testCase.IgnoredProperties);
 
-            // Execute
+            // Verify
             configureByIgnoringAction
                 .Should()
                 .Throw<Exception>()

--- a/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringWhereTests.cs
+++ b/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringWhereTests.cs
@@ -45,7 +45,7 @@ namespace Destructurama.ByIgnoring.Tests
             // Execute
             Action configureByIgnoringAction = () => config.Destructure.ByIgnoringPropertiesWhere(testCase.HandleDestructuringPredicate, testCase.IgnoredPropertyPredicates);
 
-            // Execute
+            // Verify
             configureByIgnoringAction
                 .Should()
                 .Throw<Exception>()

--- a/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringWhereTests.cs
+++ b/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringWhereTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using Destructurama.ByIgnoring.Tests.Support;
 using Destructurama.ByIgnoring.Tests.TestCases;
 using FluentAssertions;
@@ -11,17 +13,16 @@ using Serilog.Events;
 namespace Destructurama.ByIgnoring.Tests
 {
     [TestFixture]
-    public class DestructureByIgnoringTests
+    public class DestructureByIgnoringWhereTests
     {
-        [TestCaseSource(typeof(ByIgnoringTestCases), nameof(ByIgnoringTestCases.DestructureMeSuccessTestCases))]
-        [TestCaseSource(typeof(ByIgnoringTestCases), nameof(ByIgnoringTestCases.OnlySetterSuccessTestCases))]
-        public void PropertiesAreIgnoredWhenDestructuring<T>(ByIgnoringTestCase<T> testCase)
+        [TestCaseSource(typeof(ByIgnoreWhereTestCases), nameof(ByIgnoreWhereTestCases.ShouldDestructureSuccessfullyTestCases))]
+        public void PropertiesAreIgnoredWhenDestructuring(ByIgnoreWhereTestCase testCase)
         {
             // Setup
             LogEvent evt = null;
 
             var log = new LoggerConfiguration()
-                .Destructure.ByIgnoringProperties(testCase.IgnoredProperties)
+                .Destructure.ByIgnoringPropertiesWhere(testCase.HandleDestructuringPredicate, testCase.IgnoredPropertyPredicates)
                 .WriteTo.Sink(new DelegatingSink(e => evt = e))
                 .CreateLogger();
 
@@ -35,14 +36,14 @@ namespace Destructurama.ByIgnoring.Tests
             props.Should().BeEquivalentTo(testCase.ExpectedPropertiesLogged);
         }
 
-        [TestCaseSource(typeof(ByIgnoringTestCases), nameof(ByIgnoringTestCases.ShouldThrowExceptionTestCases))]
-        public void ExceptionThrownWhenRegisteringDestructure<T>(ByIgnoreExceptionTestCase<T> testCase)
+        [TestCaseSource(typeof(ByIgnoreWhereTestCases), nameof(ByIgnoreWhereTestCases.ShouldThrowExceptionTestCases))]
+        public void ExceptionThrownWhenRegisteringDestructure(ByIgnoreWhereExceptionTestCase testCase)
         {
             // Setup
             var config = new LoggerConfiguration();
 
             // Execute
-            Action configureByIgnoringAction = () => config.Destructure.ByIgnoringProperties(testCase.IgnoredProperties);
+            Action configureByIgnoringAction = () => config.Destructure.ByIgnoringPropertiesWhere(testCase.HandleDestructuringPredicate, testCase.IgnoredPropertyPredicates);
 
             // Execute
             configureByIgnoringAction

--- a/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringWhereTests.cs
+++ b/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringWhereTests.cs
@@ -47,7 +47,7 @@ namespace Destructurama.ByIgnoring.Tests
             var sv = (StructureValue)evt.Properties["Ignored"];
             var props = sv.Properties.ToDictionary(p => p.Name, p => p.Value);
 
-            props.Should().BeEquivalentTo(testCase.ExpectedPropertiesLogged);
+            props.Should().BeEquivalentTo(testCase.ExpectedPropertiesLogged, options => options.UsingSerilogTypeComparisons());
         }
 
         [TestCaseSource(typeof(ByIgnoreWhereTestCases), nameof(ByIgnoreWhereTestCases.ShouldThrowExceptionTestCases))]

--- a/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringWhereTests.cs
+++ b/test/Destructurama.ByIgnoring.Tests/DestructureByIgnoringWhereTests.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/test/Destructurama.ByIgnoring.Tests/Support/FluentAssertionExtensions.cs
+++ b/test/Destructurama.ByIgnoring.Tests/Support/FluentAssertionExtensions.cs
@@ -1,0 +1,19 @@
+// (C) Copyright 2023 Nullable, Inc. All rights reserved.
+// This file is part of Nullable's product Aware and cannot be copied and/or
+// distributed without the express permission of Nullable, Inc.
+
+using FluentAssertions;
+using FluentAssertions.Equivalency;
+using Serilog.Events;
+
+namespace Destructurama.ByIgnoring.Tests.Support;
+
+public static class FluentAssertionExtensions
+{
+    public static EquivalencyAssertionOptions<T> UsingSerilogTypeComparisons<T>(this EquivalencyAssertionOptions<T> options)
+    {
+        return options
+            .Using<ScalarValue>(ctx => ctx.Subject.Value.Should().BeEquivalentTo(ctx.Expectation.Value))
+            .WhenTypeIs<ScalarValue>();
+    }
+}

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoreWhereTestCases.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoreWhereTestCases.cs
@@ -1,6 +1,16 @@
-// (C) Copyright 2023 Nullable, Inc. All rights reserved.
-// This file is part of Nullable's product Aware and cannot be copied and/or
-// distributed without the express permission of Nullable, Inc.
+// Copyright 2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 using System;
 using System.Collections.Generic;

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoreWhereTestCases.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoreWhereTestCases.cs
@@ -57,7 +57,7 @@ public class ByIgnoreWhereTestCases
             },
         };
 
-        foreach (var scenario in ConvertFromByIgnoringScenarios())
+        foreach (var scenario in Convert(ByIgnoringTestCases.DestructureMeSuccessTestCases()))
             yield return scenario;
     }
 
@@ -96,17 +96,9 @@ public class ByIgnoreWhereTestCases
         };
     }
 
-    private static IEnumerable<ByIgnoreWhereTestCase> ConvertFromByIgnoringScenarios()
+    private static IEnumerable<ByIgnoreWhereTestCase> Convert(IEnumerable<ByIgnoringTestCase<DestructureMe>> input)
     {
-        // It isn't great that this test has knowledge of ByIgnoringTestCases's types, but this seems like an ok concession.
-        if (ByIgnoringTestCases.DestructureMeSuccessTestCases().Any(x => x.MyType != typeof(DestructureMe)))
-        {
-            throw new ApplicationException(
-                $"It looks like {nameof(ByIgnoringTestCases)}.{nameof(ByIgnoringTestCases.DestructureMeSuccessTestCases)} is returning a generic other than {nameof(DestructureMe)}." +
-                $"In order to prevent duplicate tests we generate test cases assuming this type is used.");
-        }
-
-        return ByIgnoringTestCases.DestructureMeSuccessTestCases()
+        return input
             .Select(x => new ByIgnoreWhereTestCase(x.TestName)
             {
                 HandleDestructuringPredicate = obj => obj.GetType() == typeof(DestructureMe),

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoreWhereTestCases.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoreWhereTestCases.cs
@@ -58,7 +58,14 @@ public class ByIgnoreWhereTestCases
         };
 
         foreach (var scenario in Convert(ByIgnoringTestCases.DestructureMeSuccessTestCases()))
+        {
             yield return scenario;
+        }
+
+        foreach (var scenario in Convert(ByIgnoringTestCases.OnlySetterSuccessTestCases()))
+        {
+            yield return scenario;
+        }
     }
 
     public static IEnumerable<ByIgnoreWhereExceptionTestCase> ShouldThrowExceptionTestCases()
@@ -96,14 +103,14 @@ public class ByIgnoreWhereTestCases
         };
     }
 
-    private static IEnumerable<ByIgnoreWhereTestCase> Convert(IEnumerable<ByIgnoringTestCase<DestructureMe>> input)
+    private static IEnumerable<ByIgnoreWhereTestCase> Convert<T>(IEnumerable<ByIgnoringTestCase<T>> input)
     {
         return input
             .Select(x => new ByIgnoreWhereTestCase(x.TestName)
             {
-                HandleDestructuringPredicate = obj => obj.GetType() == typeof(DestructureMe),
+                HandleDestructuringPredicate = obj => obj.GetType() == typeof(T),
                 IgnoredPropertyPredicates = x.IgnoredProperties
-                    .Select<Expression<Func<DestructureMe, object>>, Func<PropertyInfo, bool>>(
+                    .Select<Expression<Func<T, object>>, Func<PropertyInfo, bool>>(
                         // It's also not great that we're using sut code - GetPropertyNameFromExpression() - in our test. This is edging towards tautological. But I've got nothing better at the moment other than duplicating scenarios
                         destructureMe => propertyInfo => propertyInfo.Name == destructureMe.GetPropertyNameFromExpression())
                     .ToArray(),

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoreWhereTestCases.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoreWhereTestCases.cs
@@ -1,0 +1,137 @@
+// (C) Copyright 2023 Nullable, Inc. All rights reserved.
+// This file is part of Nullable's product Aware and cannot be copied and/or
+// distributed without the express permission of Nullable, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Serilog.Events;
+
+namespace Destructurama.ByIgnoring.Tests.TestCases;
+
+public class ByIgnoreWhereTestCases
+{
+    public static IEnumerable<ByIgnoreWhereTestCase> ShouldDestructureSuccessfullyTestCases()
+    {
+        yield return new ByIgnoreWhereTestCase("given matching handle predicate, then ignore properties according to supplied predicates")
+        {
+            HandleDestructuringPredicate = obj => obj.GetType() == typeof(DestructureMe),
+            IgnoredPropertyPredicates = new Func<PropertyInfo, bool>[]
+            {
+                pi => pi.Name == nameof(DestructureMe.Id), // value type property
+                pi => pi.Name == nameof(DestructureMe.Password), // reference type property
+            },
+            ObjectToDestructure = new DestructureMe
+            {
+                Id = 2,
+                Name = "CoolName",
+                Password = "Password",
+            },
+            ExpectedPropertiesLogged = new Dictionary<string, LogEventPropertyValue>
+            {
+                { "Name", new ScalarValue("CoolName") },
+            },
+        };
+
+        yield return new ByIgnoreWhereTestCase("given a non-matching handle predicate, then log entire object")
+        {
+            HandleDestructuringPredicate = obj => obj.GetType() == typeof(DestructureMe),
+            IgnoredPropertyPredicates = new Func<PropertyInfo, bool>[]
+            {
+                pi => pi.Name == nameof(DestructureMe.Id), // value type property
+                pi => pi.Name == nameof(DestructureMe.Password), // reference type property
+            },
+            ObjectToDestructure = new
+            {
+                Id = 2,
+                Name = "CoolName",
+                Password = "Password",
+            },
+            ExpectedPropertiesLogged = new Dictionary<string, LogEventPropertyValue>
+            {
+                { "Id", new ScalarValue(2) },
+                { "Name", new ScalarValue("CoolName") },
+                { "Password", new ScalarValue("Password") },
+            },
+        };
+
+        foreach (var scenario in ConvertFromByIgnoringScenarios())
+            yield return scenario;
+    }
+
+    public static IEnumerable<ByIgnoreWhereExceptionTestCase> ShouldThrowExceptionTestCases()
+    {
+        yield return new ByIgnoreWhereExceptionTestCase("null handleDestructuringPredicate")
+        {
+            HandleDestructuringPredicate = null,
+            IgnoredPropertyPredicates = new Func<PropertyInfo, bool>[]
+            {
+                pi => pi.Name == nameof(DestructureMe.Id),
+                pi => pi.Name == nameof(DestructureMe.Password),
+            },
+            ExceptionType = typeof(ArgumentNullException),
+        };
+
+        yield return new ByIgnoreWhereExceptionTestCase("null ignoredPropertyPredicates")
+        {
+            HandleDestructuringPredicate = obj => obj is IDestructureMe,
+            IgnoredPropertyPredicates = null,
+            ExceptionType = typeof(ArgumentNullException),
+        };
+
+        yield return new ByIgnoreWhereExceptionTestCase("null handleDestructuringPredicate and null ignoredPropertyPredicates")
+        {
+            HandleDestructuringPredicate = null,
+            IgnoredPropertyPredicates = null,
+            ExceptionType = typeof(ArgumentNullException),
+        };
+
+        yield return new ByIgnoreWhereExceptionTestCase("empty ignoredPropertyPredicates")
+        {
+            HandleDestructuringPredicate = obj => obj is IDestructureMe,
+            IgnoredPropertyPredicates = Array.Empty<Func<PropertyInfo, bool>>(),
+            ExceptionType = typeof(ArgumentOutOfRangeException),
+        };
+    }
+
+    private static IEnumerable<ByIgnoreWhereTestCase> ConvertFromByIgnoringScenarios()
+    {
+        // It isn't great that this test has knowledge of ByIgnoringTestCases's types, but this seems like an ok concession.
+        if (ByIgnoringTestCases.DestructureMeSuccessTestCases().Any(x => x.MyType != typeof(DestructureMe)))
+        {
+            throw new ApplicationException(
+                $"It looks like {nameof(ByIgnoringTestCases)}.{nameof(ByIgnoringTestCases.DestructureMeSuccessTestCases)} is returning a generic other than {nameof(DestructureMe)}." +
+                $"In order to prevent duplicate tests we generate test cases assuming this type is used.");
+        }
+
+        return ByIgnoringTestCases.DestructureMeSuccessTestCases()
+            .Select(x => new ByIgnoreWhereTestCase(x.TestName)
+            {
+                HandleDestructuringPredicate = obj => obj.GetType() == typeof(DestructureMe),
+                IgnoredPropertyPredicates = x.IgnoredProperties
+                    .Select<Expression<Func<DestructureMe, object>>, Func<PropertyInfo, bool>>(
+                        // It's also not great that we're using sut code - GetPropertyNameFromExpression() - in our test. This is edging towards tautological. But I've got nothing better at the moment other than duplicating scenarios
+                        destructureMe => propertyInfo => propertyInfo.Name == destructureMe.GetPropertyNameFromExpression())
+                    .ToArray(),
+                ObjectToDestructure = x.ObjectToDestructure,
+                ExpectedPropertiesLogged = x.ExpectedPropertiesLogged,
+            });
+    }
+}
+
+public record ByIgnoreWhereTestCase(string TestName)
+{
+    public Func<object, bool> HandleDestructuringPredicate { get; set; }
+    public Func<PropertyInfo, bool>[] IgnoredPropertyPredicates { get; set; }
+    public object ObjectToDestructure { get; set; }
+    public IDictionary<string, LogEventPropertyValue> ExpectedPropertiesLogged { get; set; }
+}
+
+public record ByIgnoreWhereExceptionTestCase(string TestName)
+{
+    public Func<object, bool> HandleDestructuringPredicate { get; set; }
+    public Func<PropertyInfo, bool>[] IgnoredPropertyPredicates { get; set; }
+    public Type ExceptionType { get; set; }
+}

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoringPropertiesOfTypeAssignableToTestCases.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoringPropertiesOfTypeAssignableToTestCases.cs
@@ -1,3 +1,17 @@
+// Copyright 2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoringPropertiesOfTypeAssignableToTestCases.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoringPropertiesOfTypeAssignableToTestCases.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Serilog.Events;
+
+namespace Destructurama.ByIgnoring.Tests.TestCases;
+
+public class ByIgnoringPropertiesOfTypeAssignableToTestCases
+{
+    public static IEnumerable<ByIgnoringTestCase<IDestructureMe>> IDestructureMeSuccessTestCases()
+    {
+        // TODO - I can't figure out a way to convert these from DestructureMeSuccessTestCases.ByIgnoringTestCases(), so we'll duplicate the scenarios here and change the type. If someone can figure this out please make them more like ByIgnoringWhereTestCases.cs
+        yield return new ByIgnoringTestCase<IDestructureMe>("Ignore id and password should only include name")
+        {
+            IgnoredProperties = new Expression<Func<IDestructureMe, object>>[]
+            {
+                dm => dm.Id, // value type property
+                dm => dm.Password, // reference type property
+            },
+            ObjectToDestructure = new DestructureMe
+            {
+                Id = 2,
+                Name = "CoolName",
+                Password = "Password",
+            },
+            ExpectedPropertiesLogged = new Dictionary<string, LogEventPropertyValue>
+            {
+                { "Name", new ScalarValue("CoolName") },
+            },
+        };
+
+        yield return new ByIgnoringTestCase<IDestructureMe>("Ignore just id should include two others")
+        {
+            IgnoredProperties = new Expression<Func<IDestructureMe, object>>[]
+            {
+                dm => dm.Id, // value type property
+            },
+            ObjectToDestructure = new DestructureMe
+            {
+                Id = 2,
+                Name = "CoolName",
+                Password = "Password",
+            },
+            ExpectedPropertiesLogged = new Dictionary<string, LogEventPropertyValue>
+            {
+                { "Name", new ScalarValue("CoolName") },
+                { "Password", new ScalarValue("Password") },
+            },
+        };
+
+        yield return new ByIgnoringTestCase<IDestructureMe>("Ignore just password should include two others")
+        {
+            IgnoredProperties = new Expression<Func<IDestructureMe, object>>[]
+            {
+                dm => dm.Password, // reference type property
+            },
+            ObjectToDestructure = new DestructureMe
+            {
+                Id = 2,
+                Name = "CoolName",
+                Password = "Password",
+            },
+            ExpectedPropertiesLogged = new Dictionary<string, LogEventPropertyValue>
+            {
+                { "Id", new ScalarValue(2) },
+                { "Name", new ScalarValue("CoolName") },
+            },
+        };
+
+        yield return new ByIgnoringTestCase<IDestructureMe>("Ignoring all properties should produce empty object")
+        {
+            IgnoredProperties = new Expression<Func<IDestructureMe, object>>[]
+            {
+                dm => dm.Password,
+                dm => dm.Name,
+                dm => dm.Id,
+            },
+            ObjectToDestructure = new DestructureMe
+            {
+                Id = 2,
+                Name = "CoolName",
+                Password = "Password",
+            },
+            ExpectedPropertiesLogged = new Dictionary<string, LogEventPropertyValue>(),
+        };
+
+        yield return new ByIgnoringTestCase<IDestructureMe>("Destructure policy shouldn't come into play for other types")
+        {
+            IgnoredProperties = new Expression<Func<IDestructureMe, object>>[]
+            {
+                dm => dm.Password, // reference type property
+            },
+            ObjectToDestructure = new ByIgnoringTestCases.SomeOtherType
+            {
+                FullName = "Darth Vadar",
+            },
+            ExpectedPropertiesLogged = new Dictionary<string, LogEventPropertyValue>
+            {
+                { "FullName", new ScalarValue("Darth Vadar") },
+            },
+        };
+    }
+
+    public static IEnumerable<ByIgnoreExceptionTestCase<IDestructureMe>> ShouldThrowExceptionTestCases()
+    {
+        // TODO - I can't figure out a way to convert these from DestructureMeSuccessTestCases.ShouldThrowExceptionTestCases(), so we'll duplicate the scenarios here and change the type. If someone can figure this out please make them more like ByIgnoringWhereTestCases.cs
+        yield return new ByIgnoreExceptionTestCase<IDestructureMe>("ComplexExpressionsFail")
+        {
+            IgnoredProperties = new Expression<Func<IDestructureMe, object>>[]
+            {
+                dm => new
+                {
+                    Name = dm.Name,
+                }
+            },
+            ExceptionType = typeof(ArgumentException),
+        };
+
+        yield return new ByIgnoreExceptionTestCase<IDestructureMe>("MethodExpressionsFail")
+        {
+            IgnoredProperties = new Expression<Func<IDestructureMe, object>>[]
+            {
+                dm => dm.ToString(),
+            },
+            ExceptionType = typeof(ArgumentException),
+        };
+
+        yield return new ByIgnoreExceptionTestCase<IDestructureMe>("StringLiteralExpressionsFail")
+        {
+            IgnoredProperties = new Expression<Func<IDestructureMe, object>>[]
+            {
+                dm => "string literal",
+            },
+            ExceptionType = typeof(ArgumentException),
+        };
+
+        yield return new ByIgnoreExceptionTestCase<IDestructureMe>("ChainedPropertyExpressionsFail")
+        {
+            IgnoredProperties = new Expression<Func<IDestructureMe, object>>[]
+            {
+                dm => dm.Password.Length
+            },
+            ExceptionType = typeof(ArgumentException),
+        };
+    }
+}

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoringPropertiesOfTypeAssignableToTestCases.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoringPropertiesOfTypeAssignableToTestCases.cs
@@ -10,7 +10,7 @@ public class ByIgnoringPropertiesOfTypeAssignableToTestCases
 {
     public static IEnumerable<ByIgnoringTestCase<IDestructureMe>> IDestructureMeSuccessTestCases()
     {
-        // TODO - I can't figure out a way to convert these from DestructureMeSuccessTestCases.ByIgnoringTestCases(), so we'll duplicate the scenarios here and change the type. If someone can figure this out please make them more like ByIgnoringWhereTestCases.cs
+        // TODO - I can't figure out a way to convert these from ByIgnoringTestCases.DestructureMeSuccessTestCases(), so we'll duplicate the scenarios here and change the type. If someone can figure this out please make them more like ByIgnoringWhereTestCases.cs
         yield return new ByIgnoringTestCase<IDestructureMe>("Ignore id and password should only include name")
         {
             IgnoredProperties = new Expression<Func<IDestructureMe, object>>[]
@@ -104,7 +104,7 @@ public class ByIgnoringPropertiesOfTypeAssignableToTestCases
 
     public static IEnumerable<ByIgnoreExceptionTestCase<IDestructureMe>> ShouldThrowExceptionTestCases()
     {
-        // TODO - I can't figure out a way to convert these from DestructureMeSuccessTestCases.ShouldThrowExceptionTestCases(), so we'll duplicate the scenarios here and change the type. If someone can figure this out please make them more like ByIgnoringWhereTestCases.cs
+        // TODO - I can't figure out a way to convert these from ByIgnoringTestCases.ShouldThrowExceptionTestCases(), so we'll duplicate the scenarios here and change the type. If someone can figure this out please make them more like ByIgnoringWhereTestCases.cs
         yield return new ByIgnoreExceptionTestCase<IDestructureMe>("ComplexExpressionsFail")
         {
             IgnoredProperties = new Expression<Func<IDestructureMe, object>>[]

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoringTestCases.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoringTestCases.cs
@@ -15,7 +15,6 @@ public record ByIgnoringTestCase<TDestructure>(string TestName)
     public Expression<Func<TDestructure, object>>[] IgnoredProperties { get; set; }
     public object ObjectToDestructure { get; set; }
     public IDictionary<string, LogEventPropertyValue> ExpectedPropertiesLogged { get; set; }
-    public Type MyType => typeof(TDestructure);
 }
 
 public record ByIgnoreExceptionTestCase<TDestructure>(string TestName)

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoringTestCases.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoringTestCases.cs
@@ -1,6 +1,16 @@
-// (C) Copyright 2023 Nullable, Inc. All rights reserved.
-// This file is part of Nullable's product Aware and cannot be copied and/or
-// distributed without the express permission of Nullable, Inc.
+// Copyright 2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 using System;
 using System.Collections.Generic;

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoringTestCases.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoringTestCases.cs
@@ -1,0 +1,203 @@
+// (C) Copyright 2023 Nullable, Inc. All rights reserved.
+// This file is part of Nullable's product Aware and cannot be copied and/or
+// distributed without the express permission of Nullable, Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Serilog.Events;
+
+namespace Destructurama.ByIgnoring.Tests.TestCases;
+
+public record ByIgnoringTestCase<TDestructure>(string TestName)
+{
+    public Expression<Func<TDestructure, object>>[] IgnoredProperties { get; set; }
+    public object ObjectToDestructure { get; set; }
+    public IDictionary<string, LogEventPropertyValue> ExpectedPropertiesLogged { get; set; }
+    public Type MyType => typeof(TDestructure);
+}
+
+public record ByIgnoreExceptionTestCase<TDestructure>(string TestName)
+{
+    public Expression<Func<TDestructure, object>>[] IgnoredProperties { get; set; }
+    public Type ExceptionType { get; set; }
+}
+
+public class ByIgnoringTestCases
+{
+    public static IEnumerable<ByIgnoringTestCase<DestructureMe>> DestructureMeSuccessTestCases()
+    {
+        yield return new ByIgnoringTestCase<DestructureMe>("Ignore id and password should only include name")
+        {
+            IgnoredProperties = new Expression<Func<DestructureMe, object>>[]
+            {
+                dm => dm.Id, // value type property
+                dm => dm.Password, // reference type property
+            },
+            ObjectToDestructure = new DestructureMe
+            {
+                Id = 2,
+                Name = "CoolName",
+                Password = "Password",
+            },
+            ExpectedPropertiesLogged = new Dictionary<string, LogEventPropertyValue>
+            {
+                { "Name", new ScalarValue("CoolName") },
+            },
+        };
+
+        yield return new ByIgnoringTestCase<DestructureMe>("Ignore just id should include two others")
+        {
+            IgnoredProperties = new Expression<Func<DestructureMe, object>>[]
+            {
+                dm => dm.Id, // value type property
+            },
+            ObjectToDestructure = new DestructureMe
+            {
+                Id = 2,
+                Name = "CoolName",
+                Password = "Password",
+            },
+            ExpectedPropertiesLogged = new Dictionary<string, LogEventPropertyValue>
+            {
+                { "Name", new ScalarValue("CoolName") },
+                { "Password", new ScalarValue("Password") },
+            },
+        };
+
+        yield return new ByIgnoringTestCase<DestructureMe>("Ignore just password should include two others")
+        {
+            IgnoredProperties = new Expression<Func<DestructureMe, object>>[]
+            {
+                dm => dm.Password, // reference type property
+            },
+            ObjectToDestructure = new DestructureMe
+            {
+                Id = 2,
+                Name = "CoolName",
+                Password = "Password",
+            },
+            ExpectedPropertiesLogged = new Dictionary<string, LogEventPropertyValue>
+            {
+                { "Id", new ScalarValue(2) },
+                { "Name", new ScalarValue("CoolName") },
+            },
+        };
+
+        yield return new ByIgnoringTestCase<DestructureMe>("Ignoring all properties should produce empty object")
+        {
+            IgnoredProperties = new Expression<Func<DestructureMe, object>>[]
+            {
+                dm => dm.Password,
+                dm => dm.Name,
+                dm => dm.Id,
+            },
+            ObjectToDestructure = new DestructureMe
+            {
+                Id = 2,
+                Name = "CoolName",
+                Password = "Password",
+            },
+            ExpectedPropertiesLogged = new Dictionary<string, LogEventPropertyValue>(),
+        };
+
+        yield return new ByIgnoringTestCase<DestructureMe>("Destructure policy shouldn't come into play for other types")
+        {
+            IgnoredProperties = new Expression<Func<DestructureMe, object>>[]
+            {
+                dm => dm.Password, // reference type property
+            },
+            ObjectToDestructure = new SomeOtherType
+            {
+                FullName = "Darth Vadar",
+            },
+            ExpectedPropertiesLogged = new Dictionary<string, LogEventPropertyValue>
+            {
+                { "FullName", new ScalarValue("Darth Vadar") },
+            },
+        };
+    }
+
+    public static IEnumerable<ByIgnoringTestCase<DestructureMeWithPropertyWithOnlySetter>> OnlySetterSuccessTestCases()
+    {
+        yield return new ByIgnoringTestCase<DestructureMeWithPropertyWithOnlySetter>("ClassWithAPropertyOnlyWithSetterDoesNotCrash")
+        {
+            IgnoredProperties = new Expression<Func<DestructureMeWithPropertyWithOnlySetter, object>>[]
+            {
+                dm => dm.Id, // value type property
+                dm => dm.Password, // reference type property
+            },
+            ObjectToDestructure = new DestructureMe
+            {
+                Id = 2,
+                Name = "CoolName",
+                Password = "Password",
+            },
+            // TODO - is this really the behavior we want? Leaving as is for now to be functionally equivalent, but it
+            // would seem to me that we would either want to throw an exception or actually ignore Id and Password as the consumer intends.
+            ExpectedPropertiesLogged = new Dictionary<string, LogEventPropertyValue>
+            {
+                { "Id", new ScalarValue("2") },
+                { "Name", new ScalarValue("CoolName") },
+                { "Password", new ScalarValue("Password") },
+            },
+        };
+    }
+
+    public static IEnumerable<ByIgnoreExceptionTestCase<DestructureMe>> ShouldThrowExceptionTestCases()
+    {
+        yield return new ByIgnoreExceptionTestCase<DestructureMe>("ComplexExpressionsFail")
+        {
+            IgnoredProperties = new Expression<Func<DestructureMe, object>>[]
+            {
+                dm => new
+                {
+                    Name = dm.Name,
+                }
+            },
+            ExceptionType = typeof(ArgumentException),
+        };
+
+        yield return new ByIgnoreExceptionTestCase<DestructureMe>("MethodExpressionsFail")
+        {
+            IgnoredProperties = new Expression<Func<DestructureMe, object>>[]
+            {
+                dm => dm.ToString(),
+            },
+            ExceptionType = typeof(ArgumentException),
+        };
+
+        yield return new ByIgnoreExceptionTestCase<DestructureMe>("StringLiteralExpressionsFail")
+        {
+            IgnoredProperties = new Expression<Func<DestructureMe, object>>[]
+            {
+                dm => "string literal",
+            },
+            ExceptionType = typeof(ArgumentException),
+        };
+
+        yield return new ByIgnoreExceptionTestCase<DestructureMe>("ChainedPropertyExpressionsFail")
+        {
+            IgnoredProperties = new Expression<Func<DestructureMe, object>>[]
+            {
+                dm => dm.Password.Length
+            },
+            ExceptionType = typeof(ArgumentException),
+        };
+    }
+
+    public class DestructureMeWithPropertyWithOnlySetter
+    {
+        private string _onlySetter;
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Password { get; set; }
+        public string OnlySetter { set { _onlySetter = value; } }
+    }
+
+    public class SomeOtherType
+    {
+        public string FullName { get; set; }
+    }
+}

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoringTestCases.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/ByIgnoringTestCases.cs
@@ -147,7 +147,7 @@ public class ByIgnoringTestCases
             // would seem to me that we would either want to throw an exception or actually ignore Id and Password as the consumer intends.
             ExpectedPropertiesLogged = new Dictionary<string, LogEventPropertyValue>
             {
-                { "Id", new ScalarValue("2") },
+                { "Id", new ScalarValue(2) },
                 { "Name", new ScalarValue("CoolName") },
                 { "Password", new ScalarValue("Password") },
             },

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/DestructureMe.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/DestructureMe.cs
@@ -1,0 +1,14 @@
+// (C) Copyright 2023 Nullable, Inc. All rights reserved.
+// This file is part of Nullable's product Aware and cannot be copied and/or
+// distributed without the express permission of Nullable, Inc.
+
+namespace Destructurama.ByIgnoring.Tests.TestCases;
+
+public class DestructureMe : IDestructureMe
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Password { get; set; }
+    public static string SomeStatic { get; set; } = "AAA";
+    public string this[int index] => "value";
+}

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/DestructureMe.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/DestructureMe.cs
@@ -1,6 +1,16 @@
-// (C) Copyright 2023 Nullable, Inc. All rights reserved.
-// This file is part of Nullable's product Aware and cannot be copied and/or
-// distributed without the express permission of Nullable, Inc.
+// Copyright 2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Destructurama.ByIgnoring.Tests.TestCases;
 

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/IDestructureMe.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/IDestructureMe.cs
@@ -1,0 +1,12 @@
+// (C) Copyright 2023 Nullable, Inc. All rights reserved.
+// This file is part of Nullable's product Aware and cannot be copied and/or
+// distributed without the express permission of Nullable, Inc.
+
+namespace Destructurama.ByIgnoring.Tests.TestCases;
+
+public interface IDestructureMe
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Password { get; set; }
+}

--- a/test/Destructurama.ByIgnoring.Tests/TestCases/IDestructureMe.cs
+++ b/test/Destructurama.ByIgnoring.Tests/TestCases/IDestructureMe.cs
@@ -1,6 +1,16 @@
-// (C) Copyright 2023 Nullable, Inc. All rights reserved.
-// This file is part of Nullable's product Aware and cannot be copied and/or
-// distributed without the express permission of Nullable, Inc.
+// Copyright 2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Destructurama.ByIgnoring.Tests.TestCases;
 


### PR DESCRIPTION
This adds a `ByIgnoringPropertiesOfTypeAssignableTo<T>()` extension method. My use case is that I want to ignore particular properties on all objects that are derived from a particular interface.

In order to do this I refactored the core to be more extensible such that others can write their own extension methods to ignore properties under other conditions.